### PR TITLE
deployment.yaml, values.yaml - add ENV TARANTOOL_CLUSTER_COOKIE and ClusterCookie definition

### DIFF
--- a/examples/kv/helm-chart/templates/deployment.yaml
+++ b/examples/kv/helm-chart/templates/deployment.yaml
@@ -124,6 +124,10 @@ spec:
               value: "60"
             - name: TARANTOOL_HTTP_PORT
               value: "8081"
+            {{- if $.Values.ClusterCookie }}
+            - name: TARANTOOL_CLUSTER_COOKIE
+              value: "{{ $.Values.ClusterCookie }}"
+            {{- end }}
           readinessProbe:
             tcpSocket:
               port: http

--- a/examples/kv/helm-chart/values.yaml
+++ b/examples/kv/helm-chart/values.yaml
@@ -3,6 +3,7 @@
 ClusterEnv: dev
 ClusterName: examples-kv-cluster
 ClusterDomainName: cluster.local
+ClusterCookie: "tnt-kv-cookie"
 TarantoolWorkDir: /var/lib/tarantool
 LuaMemoryReserveMB: 2048
 

--- a/examples/kv/helm-chart/values.yaml
+++ b/examples/kv/helm-chart/values.yaml
@@ -3,7 +3,7 @@
 ClusterEnv: dev
 ClusterName: examples-kv-cluster
 ClusterDomainName: cluster.local
-ClusterCookie: "tnt-kv-cookie"
+# ClusterCookie: "tnt-kv-cookie"      # example, uncomment to override application/yaml level definition of cluster cookie
 TarantoolWorkDir: /var/lib/tarantool
 LuaMemoryReserveMB: 2048
 


### PR DESCRIPTION
add new ENV variable in deployment.yaml for cluster cookie, based on ClusterCookie defined in helm chart values.
add sample ClusterCookie definition to values.yaml.
can be used for https://github.com/tarantool/tarantool-operator/issues/112